### PR TITLE
Added optional remote trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@
       --host=<host>    If starting server, specify ip address to bind to.
                        Default is 127.0.0.1
       --port=<port>    Specify server port number. Default is 9288
-      --remote-trigger Defer printing until page evaluates the following:
-                       window.cefPdf({request: "", onSuccess: function () {}, onFailure: function () {}});
-
+      --remote-trigger Defer printing until page evaluates window.triggerCefPdf()
 
     Output:
       PDF file name to create. Default is to write binary data to standard output.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
       --host=<host>    If starting server, specify ip address to bind to.
                        Default is 127.0.0.1
       --port=<port>    Specify server port number. Default is 9288
+      --remote-trigger Defer printing until page evaluates the following:
+                       window.cefPdf({request: "", onSuccess: function () {}, onFailure: function () {}});
+
 
     Output:
       PDF file name to create. Default is to write binary data to standard output.

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -166,7 +166,10 @@ void Client::OnContextInitialized()
     CreateBrowsers();
 
     if (!m_requestHandler->m_messageRouterBrowserSide) {
-        m_requestHandler->m_messageRouterBrowserSide = CefMessageRouterBrowserSide::Create(constants::messageRouterConfig);
+        CefMessageRouterConfig config;
+        config.js_query_function = constants::jsQueryFunction;
+        config.js_cancel_function = constants::jsCancelFunction;
+        m_requestHandler->m_messageRouterBrowserSide = CefMessageRouterBrowserSide::Create(config);
         m_requestHandler->m_messageRouterBrowserSide->AddHandler(this, true);
     }
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -218,15 +218,18 @@ void Client::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 
     CEF_REQUIRE_UI_THREAD();
 
-    CefRefPtr<CefFrame> frame = browser->GetMainFrame();
+    if (m_remoteTrigger) {
+        CefRefPtr<CefFrame> frame = browser->GetMainFrame();
 
-    frame->ExecuteJavaScript(
-        "window.triggerCefPdf = function () { window."
-        + constants::jsQueryFunction
-        + "({request: "", onSuccess: function () {}, onFailure: function () {}}); };"
-        , frame->GetURL()
-        , 0
-    );
+        frame->ExecuteJavaScript(
+            "window.triggerCefPdf = function () { window."
+            + constants::jsQueryFunction
+            + "({request: "", onSuccess: function () {}, onFailure: function () {}}); };"
+            , frame->GetURL()
+            , 0
+        );
+    }
+
     // Assign this browser to the next job. JobsManager will
     // check if there is any queued job
     m_jobManager->Assign(browser);

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -218,6 +218,15 @@ void Client::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 
     CEF_REQUIRE_UI_THREAD();
 
+    CefRefPtr<CefFrame> frame = browser->GetMainFrame();
+
+    frame->ExecuteJavaScript(
+        "window.triggerCefPdf = function () { window."
+        + constants::jsQueryFunction
+        + "({request: "", onSuccess: function () {}, onFailure: function () {}}); };"
+        , frame->GetURL()
+        , 0
+    );
     // Assign this browser to the next job. JobsManager will
     // check if there is any queued job
     m_jobManager->Assign(browser);

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -210,8 +210,10 @@ void Client::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 
     CEF_REQUIRE_UI_THREAD();
 
-    m_requestHandler->m_messageRouterBrowserSide = CefMessageRouterBrowserSide::Create(constants::messageRouterConfig);
-    m_requestHandler->m_messageRouterBrowserSide->AddHandler(this, true);
+    if (!m_requestHandler->m_messageRouterBrowserSide) {
+        m_requestHandler->m_messageRouterBrowserSide = CefMessageRouterBrowserSide::Create(constants::messageRouterConfig);
+        m_requestHandler->m_messageRouterBrowserSide->AddHandler(this, true);
+    }
 
     // Assign this browser to the next job. JobsManager will
     // check if there is any queued job

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -106,7 +106,7 @@ void Client::CreateBrowsers(unsigned int browserCount)
 
 void Client::SetRemoteTrigger(bool flag)
 {
-    m_remote_trigger = flag;
+    m_remoteTrigger = flag;
 }
 
 // CefApp methods:
@@ -268,7 +268,7 @@ void Client::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
 
     CEF_REQUIRE_UI_THREAD();
 
-    if (frame->IsMain() && !m_remote_trigger) {
+    if (frame->IsMain() && !m_remoteTrigger) {
         m_jobManager->Process(browser, httpStatusCode);
     }
 }
@@ -305,7 +305,7 @@ bool Client::OnQuery(
 
     CEF_REQUIRE_UI_THREAD();
 
-    if (frame->IsMain() && m_remote_trigger) {
+    if (frame->IsMain() && m_remoteTrigger) {
         m_jobManager->Process(browser, 200);
         callback->Success("OK");
         return true;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -164,6 +164,11 @@ void Client::OnContextInitialized()
     CefRegisterSchemeHandlerFactory(constants::scheme, "", new SchemeHandlerFactory(m_jobManager));
 
     CreateBrowsers();
+
+    if (!m_requestHandler->m_messageRouterBrowserSide) {
+        m_requestHandler->m_messageRouterBrowserSide = CefMessageRouterBrowserSide::Create(constants::messageRouterConfig);
+        m_requestHandler->m_messageRouterBrowserSide->AddHandler(this, true);
+    }
 }
 
 // CefClient methods:
@@ -209,11 +214,6 @@ void Client::OnAfterCreated(CefRefPtr<CefBrowser> browser)
     DLOG(INFO) << "Client::OnAfterCreated";
 
     CEF_REQUIRE_UI_THREAD();
-
-    if (!m_requestHandler->m_messageRouterBrowserSide) {
-        m_requestHandler->m_messageRouterBrowserSide = CefMessageRouterBrowserSide::Create(constants::messageRouterConfig);
-        m_requestHandler->m_messageRouterBrowserSide->AddHandler(this, true);
-    }
 
     // Assign this browser to the next job. JobsManager will
     // check if there is any queued job

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -332,8 +332,6 @@ bool Client::OnQuery(
             callback->Failure(ERR_ABORTED, "Aborted");
             m_jobManager->Abort(browser, ERR_ABORTED);
 	    return true;
-	} else {
-            return false;
 	}
     }
     return false;

--- a/src/Client.h
+++ b/src/Client.h
@@ -139,7 +139,7 @@ private:
     bool m_contextInitialized;
     bool m_running;
     bool m_stopAfterLastJob;
-    bool m_remote_trigger;
+    bool m_remoteTrigger;
 
     CefRefPtr<CefPrintHandler> m_printHandler;
     CefRefPtr<CefRenderHandler> m_renderHandler;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -331,14 +331,6 @@ std::string getProcessId()
 #endif // OS_WIN
 }
 
-CefMessageRouterConfig getConfig()
-{
-    CefMessageRouterConfig config;
-    config.js_query_function = "cefPdf";
-    config.js_cancel_function = "cefPdfCancel";
-    return config;
-}
-
 bool fileExists(const std::string& path)
 {
 #if defined(OS_WIN)

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -331,6 +331,14 @@ std::string getProcessId()
 #endif // OS_WIN
 }
 
+CefMessageRouterConfig getConfig()
+{
+    CefMessageRouterConfig config;
+    config.js_query_function = "cefPdf";
+    config.js_cancel_function = "cefPdfCancel";
+    return config;
+}
+
 bool fileExists(const std::string& path)
 {
 #if defined(OS_WIN)

--- a/src/Common.h
+++ b/src/Common.h
@@ -2,6 +2,7 @@
 #define COMMON_H_
 
 #include "include/internal/cef_types.h"
+#include "include/wrapper/cef_message_router.h"
 
 #include <string>
 #include <list>
@@ -15,6 +16,8 @@ std::string getCurrentWorkingDirectory();
 std::string getTempDirectory();
 
 std::string getProcessId();
+
+CefMessageRouterConfig getConfig();
 
 namespace constants {
     // cef-pdf version number
@@ -38,6 +41,7 @@ namespace constants {
     const std::string tmp = getTempDirectory();
     // Current process ID
     const std::string pid = getProcessId();
+    const CefMessageRouterConfig messageRouterConfig = getConfig();
 }
 
 struct PageSize

--- a/src/Common.h
+++ b/src/Common.h
@@ -2,7 +2,6 @@
 #define COMMON_H_
 
 #include "include/internal/cef_types.h"
-#include "include/wrapper/cef_message_router.h"
 
 #include <string>
 #include <list>
@@ -16,8 +15,6 @@ std::string getCurrentWorkingDirectory();
 std::string getTempDirectory();
 
 std::string getProcessId();
-
-CefMessageRouterConfig getConfig();
 
 namespace constants {
     // cef-pdf version number
@@ -41,7 +38,8 @@ namespace constants {
     const std::string tmp = getTempDirectory();
     // Current process ID
     const std::string pid = getProcessId();
-    const CefMessageRouterConfig messageRouterConfig = getConfig();
+    const std::string jsQueryFunction = "cefPdf";
+    const std::string jsCancelFunction = "cefPdfCancel";
 }
 
 struct PageSize

--- a/src/RenderProcessHandler.cpp
+++ b/src/RenderProcessHandler.cpp
@@ -1,0 +1,55 @@
+#include "RenderProcessHandler.h"
+#include "Common.h"
+
+namespace cefpdf {
+
+RenderProcessHandler::RenderProcessHandler() {}
+
+// CefApp methods:
+CefRefPtr<CefRenderProcessHandler> RenderProcessHandler::GetRenderProcessHandler() {
+  return this;
+}
+
+// CefRenderProcessHandler methods:
+void RenderProcessHandler::OnContextCreated(
+    CefRefPtr<CefBrowser> browser,
+    CefRefPtr<CefFrame> frame,
+    CefRefPtr<CefV8Context> context
+)
+{
+    DLOG(INFO) << "RenderProcessHandler::OnContextCreated";
+    CEF_REQUIRE_RENDERER_THREAD();
+    m_messageRouterRendererSide->OnContextCreated(browser, frame, context);
+}
+
+void RenderProcessHandler::OnContextReleased(
+    CefRefPtr<CefBrowser> browser,
+    CefRefPtr<CefFrame> frame,
+    CefRefPtr<CefV8Context> context
+)
+{
+    DLOG(INFO) << "RenderProcessHandler::OnContextReleased";
+    CEF_REQUIRE_RENDERER_THREAD();
+    m_messageRouterRendererSide->OnContextReleased(browser, frame, context);
+}
+
+bool RenderProcessHandler::OnProcessMessageReceived(
+    CefRefPtr<CefBrowser> browser,
+    CefProcessId source_process,
+    CefRefPtr<CefProcessMessage> message
+) {
+    DLOG(INFO) << "RenderProcessHandler::OnProcessMessageReceived";
+    CEF_REQUIRE_RENDERER_THREAD();
+    m_messageRouterRendererSide->OnProcessMessageReceived(browser, source_process, message);
+    return true;
+}
+
+void RenderProcessHandler::OnWebKitInitialized()
+{
+    DLOG(INFO) << "RenderProcessHandler::OnWebKitInitialized";
+    CEF_REQUIRE_RENDERER_THREAD();
+    m_messageRouterRendererSide = CefMessageRouterRendererSide::Create(constants::messageRouterConfig);
+}
+
+} // namespace cefpdf
+

--- a/src/RenderProcessHandler.cpp
+++ b/src/RenderProcessHandler.cpp
@@ -48,7 +48,12 @@ void RenderProcessHandler::OnWebKitInitialized()
 {
     DLOG(INFO) << "RenderProcessHandler::OnWebKitInitialized";
     CEF_REQUIRE_RENDERER_THREAD();
-    m_messageRouterRendererSide = CefMessageRouterRendererSide::Create(constants::messageRouterConfig);
+
+    CefMessageRouterConfig config;
+    config.js_query_function = constants::jsQueryFunction;
+    config.js_cancel_function = constants::jsCancelFunction;
+
+    m_messageRouterRendererSide = CefMessageRouterRendererSide::Create(config);
 }
 
 } // namespace cefpdf

--- a/src/RenderProcessHandler.h
+++ b/src/RenderProcessHandler.h
@@ -1,0 +1,48 @@
+#ifndef RENDER_PROCESS_HANDLER_H_
+#define RENDER_PROCESS_HANDLER_H_
+
+#include "include/cef_render_process_handler.h"
+#include "include/wrapper/cef_message_router.h"
+#include "include/wrapper/cef_helpers.h"
+#include "include/cef_app.h"
+
+namespace cefpdf {
+
+class RenderProcessHandler : public CefRenderProcessHandler,
+                             public CefApp
+{
+
+public:
+    RenderProcessHandler();
+
+    // CefApp methods:
+    virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override;
+
+    // CefRenderProcessHandler methods:
+    virtual void OnContextCreated(
+        CefRefPtr<CefBrowser> browser,
+        CefRefPtr<CefFrame> frame,
+        CefRefPtr<CefV8Context> context
+    ) override;
+    virtual void OnContextReleased(
+        CefRefPtr<CefBrowser> browser,
+        CefRefPtr<CefFrame> frame,
+        CefRefPtr<CefV8Context> context
+    ) override;
+    virtual bool OnProcessMessageReceived(
+        CefRefPtr<CefBrowser> browser,
+        CefProcessId source_process,
+        CefRefPtr<CefProcessMessage> message
+    ) override;
+    virtual void OnWebKitInitialized() override;
+
+private:
+    CefRefPtr<CefMessageRouterRendererSide> m_messageRouterRendererSide;
+
+    // Include the default reference counting implementation.
+    IMPLEMENT_REFCOUNTING(RenderProcessHandler)
+};
+
+} // namespace cefpdf
+
+#endif // RENDER_PROCESS_HANDLER_H_

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -12,9 +12,13 @@ bool RequestHandler::OnBeforeBrowse(
     CefRefPtr<CefRequest> request,
     bool is_redirect
 ) {
+    DLOG(INFO) << "RequestHandler::OnBeforeBrowse";
+
+    m_messageRouterBrowserSide->OnBeforeBrowse(browser, frame);
     if (m_schemes.empty()) {
         return false;
     }
+
 
     std::string regex;
 
@@ -32,6 +36,14 @@ bool RequestHandler::OnBeforeBrowse(
     // Allow only specified schemes
     std::regex re(regex, std::regex_constants::icase);
     return !std::regex_search(url, re, std::regex_constants::match_continuous);
+}
+
+void RequestHandler::OnRenderProcessTerminated(
+    CefRefPtr<CefBrowser> browser,
+    CefRequestHandler::TerminationStatus status
+) {
+    DLOG(INFO) << "RequestHandler::OnRenderProcessTerminated";
+    m_messageRouterBrowserSide->OnRenderProcessTerminated(browser);
 }
 
 } // namespace cefpdf

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -2,6 +2,7 @@
 #define REQUEST_HANDLER_H_
 
 #include "include/cef_request_handler.h"
+#include "include/wrapper/cef_message_router.h"
 
 #include <string>
 #include <set>
@@ -36,6 +37,13 @@ public:
         CefRefPtr<CefRequest> request,
         bool is_redirect
     ) override;
+    virtual void OnRenderProcessTerminated(
+        CefRefPtr<CefBrowser> browser,
+        CefRequestHandler::TerminationStatus status
+    ) override;
+
+    // Public members: 
+    CefRefPtr<CefMessageRouterBrowserSide> m_messageRouterBrowserSide;
 
 private:
     std::set<std::string> m_schemes;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,14 +43,14 @@ void printHelp(std::string name)
     std::cout << "                   If omitted some default margin is applied." << std::endl;
     std::cout << "  --javascript     Enable JavaScript." << std::endl;
     std::cout << "  --backgrounds    Print with backgrounds. Default is without." << std::endl;
+    std::cout << "  --remote-trigger Defer printing until page evaluates the following:" << std::endl;
+    std::cout << "                   window.cefPdf({request: \"\", onSuccess: function () {}, onFailure: function () {}});" << std::endl;
     std::cout << std::endl;
     std::cout << "Server options:" << std::endl;
     std::cout << "  --server         Start HTTP server" << std::endl;
     std::cout << "  --host=<host>    If starting server, specify ip address to bind to." << std::endl;
     std::cout << "                   Default is " << cefpdf::constants::serverHost << std::endl;
     std::cout << "  --port=<port>    Specify server port number. Default is " << cefpdf::constants::serverPort << std::endl;
-    std::cout << "  --remote-trigger Defer printing until page evaluates the following:" << std::endl;
-    std::cout << "                   window.cefPdf({request: \"\", onSuccess: function () {}, onFailure: function () {}});" << std::endl;
     std::cout << std::endl;
     std::cout << "Output:" << std::endl;
     std::cout << "  PDF file name to create. Default is to write binary data to standard output." << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,8 +43,7 @@ void printHelp(std::string name)
     std::cout << "                   If omitted some default margin is applied." << std::endl;
     std::cout << "  --javascript     Enable JavaScript." << std::endl;
     std::cout << "  --backgrounds    Print with backgrounds. Default is without." << std::endl;
-    std::cout << "  --remote-trigger Defer printing until page evaluates the following:" << std::endl;
-    std::cout << "                   window.cefPdf({request: \"\", onSuccess: function () {}, onFailure: function () {}});" << std::endl;
+    std::cout << "  --remote-trigger Defer printing until page evaluates window.triggerCefPdf()" << std::endl;
     std::cout << std::endl;
     std::cout << "Server options:" << std::endl;
     std::cout << "  --server         Start HTTP server" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,10 +138,6 @@ int runJob(CefRefPtr<cefpdf::Client> app, CefRefPtr<CefCommandLine> commandLine)
             job->SetBackgrounds();
         }
 
-        if (commandLine->HasSwitch("remote-trigger")) {
-            app->SetRemoteTrigger();
-        }
-
     } catch (std::string error) {
         std::cerr << "ERROR: " << error << std::endl;
         app->Shutdown();
@@ -234,6 +230,10 @@ int main(int argc, char* argv[])
     bool javascript = commandLine->HasSwitch("javascript") || commandLine->HasSwitch("remote-trigger");
     app->Initialize(mainArgs);
     app->SetDisableJavaScript(!javascript);
+
+    if (commandLine->HasSwitch("remote-trigger")) {
+        app->SetRemoteTrigger();
+    }
 
     return commandLine->HasSwitch("server") ? runServer(app, commandLine) : runJob(app, commandLine);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,10 +133,6 @@ int runJob(CefRefPtr<cefpdf::Client> app, CefRefPtr<CefCommandLine> commandLine)
             job->SetBackgrounds();
         }
 
-        if (commandLine->HasSwitch("backgrounds")) {
-            job->SetBackgrounds();
-        }
-
     } catch (std::string error) {
         std::cerr << "ERROR: " << error << std::endl;
         app->Shutdown();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,8 @@ void printHelp(std::string name)
     std::cout << "  --host=<host>    If starting server, specify ip address to bind to." << std::endl;
     std::cout << "                   Default is " << cefpdf::constants::serverHost << std::endl;
     std::cout << "  --port=<port>    Specify server port number. Default is " << cefpdf::constants::serverPort << std::endl;
+    std::cout << "  --remote-trigger Defer printing until page evaluates the following:" << std::endl;
+    std::cout << "                   window.cefPdf({request: \"\", onSuccess: function () {}, onFailure: function () {}});" << std::endl;
     std::cout << std::endl;
     std::cout << "Output:" << std::endl;
     std::cout << "  PDF file name to create. Default is to write binary data to standard output." << std::endl;
@@ -130,6 +132,14 @@ int runJob(CefRefPtr<cefpdf::Client> app, CefRefPtr<CefCommandLine> commandLine)
 
         if (commandLine->HasSwitch("backgrounds")) {
             job->SetBackgrounds();
+        }
+
+        if (commandLine->HasSwitch("backgrounds")) {
+            job->SetBackgrounds();
+        }
+
+        if (commandLine->HasSwitch("remote-trigger")) {
+            app->SetRemoteTrigger();
         }
 
     } catch (std::string error) {
@@ -221,8 +231,9 @@ int main(int argc, char* argv[])
         return 0;
     }
 
+    bool javascript = commandLine->HasSwitch("javascript") || commandLine->HasSwitch("remote-trigger");
     app->Initialize(mainArgs);
-    app->SetDisableJavaScript(!commandLine->HasSwitch("javascript"));
+    app->SetDisableJavaScript(!javascript);
 
     return commandLine->HasSwitch("server") ? runServer(app, commandLine) : runJob(app, commandLine);
 }


### PR DESCRIPTION
`cef-pdf` is an excellent camera which takes pdf pictures of web pages as soon as it sees them.

However some web pages are not photo ready as soon as `cef-pdf` sees them.

This pr provides the option to provide a remote trigger to the web pages themselves. Rather than the photo being taken straight away the photo is taken when the web page pulls this trigger.

The web page does this by evaluating `window.triggerCefPdf()`.

An trivial example of such a web page is the following:

```
<html>
<head></head>
<body>
<script>
    setTimeout(function () {
        var t = document.createTextNode("This is a paragraph."); 
        var p = document.createElement("p"); 
        document.querySelector("body").appendChild(p);
        p.appendChild(t);
        window.triggerCefPdf();
    }, 2000);
</script>
</body>
</html>
```

In practice most examples will depend on both non trivial asynchronous JavaScript evaluation as well as HTTPS transactions of unknown and varying durations.