### PR TITLE
Removed buggy helper func insertion, abort remote trigger if not registered sync on load.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 ===
 ### 0.3.3 (2017-08-26)
 * Added `Transfer-Encoding: chunked` support for HTTP requests
+* Added `--remote-trigger` option to defer printing until JavaScript function is called
 * Added HTTP headers for pdf printing options
 * Added `/list-sizes` enpoint to list available page sizes
 * Fixed bug related to `Content-Location` handling in HTTP request

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
                        If omitted some default margin is applied.
       --javascript     Enable JavaScript.
       --backgrounds    Print with backgrounds. Default is without.
+      --remote-trigger Defer printing until page evaluates window.cefpdf.trigger()
 
     Server options:
       --server         Start HTTP server

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@
                        If omitted some default margin is applied.
       --javascript     Enable JavaScript.
       --backgrounds    Print with backgrounds. Default is without.
-      --remote-trigger Defer printing until page evaluates window.cefpdf.trigger()
+      --remote-trigger Defer printing until page evaluates:
+                       window.cefPdfQuery({request: "trigger", onSuccess: function () {}, onFailure: function () {}});
+                       Will abort immediately if the page doesn't evaluate:
+                       window.cefPdfQuery({request: "register", onSuccess: function () {}, onFailure: function () {}});
+                       synchronously during load (e.g. in a script tag in the body).
 
     Server options:
       --server         Start HTTP server

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -219,20 +219,6 @@ void Client::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 
     CEF_REQUIRE_UI_THREAD();
 
-    if (m_remoteTrigger) {
-        CefRefPtr<CefFrame> frame = browser->GetMainFrame();
-
-        std::ostringstream os;
-
-        os << "window.cefpdf = {";
-        os << "trigger: function () { window." << constants::jsQueryFunction;
-        os << "({request: \"trigger\", onSuccess: function () {}, onFailure: function () {}}); }, ";
-        os << "abort: function () { window." << constants::jsQueryFunction;
-        os << "({request: \"abort\", onSuccess: function () {}, onFailure: function () {}}); }};";
-
-        frame->ExecuteJavaScript(os.str(), frame->GetURL(), 0);
-    }
-
     // Assign this browser to the next job. JobsManager will
     // check if there is any queued job
     m_jobManager->Assign(browser);
@@ -275,6 +261,18 @@ void Client::OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> fram
         << " with url: " << frame->GetURL().ToString();
 
     CEF_REQUIRE_UI_THREAD();
+
+    if (frame->IsMain() && m_remoteTrigger) {
+        std::ostringstream os;
+
+        os << "window.cefpdf = {";
+        os << "trigger: function () { window." << constants::jsQueryFunction;
+        os << "({request: \"trigger\", onSuccess: function () {}, onFailure: function () {}}); }, ";
+        os << "abort: function () { window." << constants::jsQueryFunction;
+        os << "({request: \"abort\", onSuccess: function () {}, onFailure: function () {}}); }};";
+
+        frame->ExecuteJavaScript(os.str(), frame->GetURL(), 0);
+    }
 }
 
 void Client::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode)

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -9,6 +9,9 @@
 #include "include/wrapper/cef_helpers.h"
 #include "include/base/cef_bind.h"
 #include "include/wrapper/cef_closure_task.h"
+#include "include/wrapper/cef_message_router.h"
+
+#include <sstream>
 
 namespace cefpdf {
 
@@ -20,6 +23,7 @@ Client::Client() :
     m_contextInitialized(false),
     m_running(false),
     m_stopAfterLastJob(false),
+    m_remoteTrigger(false),
     m_printHandler(new PrintHandler),
     m_renderHandler(new RenderHandler),
     m_renderProcessHandler(new RenderProcessHandler)
@@ -101,6 +105,11 @@ void Client::CreateBrowsers(unsigned int browserCount)
     }
 }
 
+void Client::SetRemoteTrigger(bool flag)
+{
+    m_remoteTrigger = flag;
+}
+
 // CefApp methods:
 // -----------------------------------------------------------------------------
 CefRefPtr<CefBrowserProcessHandler> Client::GetBrowserProcessHandler()
@@ -156,6 +165,14 @@ void Client::OnContextInitialized()
     CefRegisterSchemeHandlerFactory(constants::scheme, "", new SchemeHandlerFactory(m_jobManager));
 
     CreateBrowsers();
+
+    if (!m_messageRouterBrowserSide) {
+        CefMessageRouterConfig config;
+        config.js_query_function = constants::jsQueryFunction;
+        config.js_cancel_function = constants::jsCancelFunction;
+        m_messageRouterBrowserSide = CefMessageRouterBrowserSide::Create(config);
+        m_messageRouterBrowserSide->AddHandler(this, true);
+    }
 }
 
 // CefClient methods:
@@ -189,6 +206,7 @@ bool Client::OnProcessMessageReceived(
 
     CEF_REQUIRE_UI_THREAD();
 
+    m_messageRouterBrowserSide->OnProcessMessageReceived(browser, source_process, message);
     return true;
 }
 
@@ -200,6 +218,20 @@ void Client::OnAfterCreated(CefRefPtr<CefBrowser> browser)
     DLOG(INFO) << "Client::OnAfterCreated";
 
     CEF_REQUIRE_UI_THREAD();
+
+    if (m_remoteTrigger) {
+        CefRefPtr<CefFrame> frame = browser->GetMainFrame();
+
+        std::ostringstream os;
+
+        os << "window.cefpdf = {";
+        os << "trigger: function () { window." << constants::jsQueryFunction;
+        os << "({request: \"trigger\", onSuccess: function () {}, onFailure: function () {}}); }, ";
+        os << "abort: function () { window." << constants::jsQueryFunction;
+        os << "({request: \"abort\", onSuccess: function () {}, onFailure: function () {}}); }};";
+
+        frame->ExecuteJavaScript(os.str(), frame->GetURL(), 0);
+    }
 
     // Assign this browser to the next job. JobsManager will
     // check if there is any queued job
@@ -224,6 +256,8 @@ void Client::OnBeforeClose(CefRefPtr<CefBrowser> browser)
     CEF_REQUIRE_UI_THREAD();
 
     --m_browsersCount;
+
+    m_messageRouterBrowserSide->OnBeforeClose(browser);
 
     if (0 == m_browsersCount && m_stopAfterLastJob) {
         CefPostDelayedTask(TID_UI, base::Bind(&Client::Stop, this), 50);
@@ -252,7 +286,7 @@ void Client::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
 
     CEF_REQUIRE_UI_THREAD();
 
-    if (frame->IsMain()) {
+    if (frame->IsMain() && !m_remoteTrigger) {
         m_jobManager->Process(browser, httpStatusCode);
     }
 }
@@ -286,6 +320,7 @@ bool Client::OnBeforeBrowse(
 ) {
     DLOG(INFO) << "Client::OnBeforeBrowse";
 
+    m_messageRouterBrowserSide->OnBeforeBrowse(browser, frame);
     if (m_schemes.empty()) {
         return false;
     }
@@ -306,6 +341,36 @@ void Client::OnRenderProcessTerminated(
     CefRequestHandler::TerminationStatus status
 ) {
     DLOG(INFO) << "Client::OnRenderProcessTerminated";
+
+    m_messageRouterBrowserSide->OnRenderProcessTerminated(browser);
+}
+
+// CefMessageRouterBrowserSide::Handler methods:
+bool Client::OnQuery(
+    CefRefPtr<CefBrowser> browser,
+    CefRefPtr<CefFrame> frame,
+    int64 query_id,
+    const CefString& request,
+    bool persistent,
+    CefRefPtr<Callback> callback
+) {
+    DLOG(INFO) << "Client::OnQuery";
+
+    CEF_REQUIRE_UI_THREAD();
+
+    if (frame->IsMain() && m_remoteTrigger) {
+        if (request == "trigger") {
+            callback->Success("Processing");
+            m_jobManager->Process(browser, 200);
+            return true;
+        } else if (request == "abort") {
+            callback->Failure(ERR_ABORTED, "Aborted");
+            m_jobManager->Abort(browser, ERR_ABORTED);
+            return true;
+        }
+    }
+
+    return false;
 }
 
 } // namespace cefpdf

--- a/src/Client.h
+++ b/src/Client.h
@@ -110,11 +110,6 @@ public:
     virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
 
     // CefLoadHandler methods:
-    virtual void OnLoadStart(
-        CefRefPtr<CefBrowser> browser,
-        CefRefPtr<CefFrame> frame,
-        TransitionType transition_type
-    ) override;
     virtual void OnLoadEnd(
         CefRefPtr<CefBrowser> browser,
         CefRefPtr<CefFrame> frame,

--- a/src/Client.h
+++ b/src/Client.h
@@ -7,6 +7,7 @@
 #include "include/cef_client.h"
 #include "include/cef_browser.h"
 #include "include/cef_request_handler.h"
+#include "include/wrapper/cef_message_router.h"
 
 #include <queue>
 #include <set>
@@ -18,7 +19,8 @@ class Client : public CefApp,
                public CefClient,
                public CefLifeSpanHandler,
                public CefLoadHandler,
-               public CefRequestHandler
+               public CefRequestHandler,
+               public CefMessageRouterBrowserSide::Handler
 {
 
 public:
@@ -77,6 +79,8 @@ public:
             m_schemes.erase(i);
         }
     }
+
+    void SetRemoteTrigger(bool flag = true);
 
     // CefApp methods:
     virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override;
@@ -137,6 +141,16 @@ public:
         CefRequestHandler::TerminationStatus status
     ) override;
 
+    // CefMessageRouterBrowserSide::Handler methods:
+    virtual bool OnQuery(
+        CefRefPtr<CefBrowser> browser,
+        CefRefPtr<CefFrame> frame,
+        int64 query_id,
+        const CefString& request,
+        bool persistent,
+        CefRefPtr<Callback> callback
+    ) override;
+
 private:
     void CreateBrowsers(unsigned int browserCount = 0);
 
@@ -151,10 +165,12 @@ private:
     bool m_contextInitialized;
     bool m_running;
     bool m_stopAfterLastJob;
+    bool m_remoteTrigger;
 
     CefRefPtr<CefPrintHandler> m_printHandler;
     CefRefPtr<CefRenderHandler> m_renderHandler;
     CefRefPtr<CefRenderProcessHandler> m_renderProcessHandler;
+    CefRefPtr<CefMessageRouterBrowserSide> m_messageRouterBrowserSide;
 
     // Include the default reference counting implementation.
     IMPLEMENT_REFCOUNTING(Client)

--- a/src/Common.h
+++ b/src/Common.h
@@ -39,7 +39,7 @@ namespace constants {
     // Current process ID
     const std::string pid = getProcessId();
 
-    // JavaScript functions
+    // JavaScript trigger functions
     const std::string jsQueryFunction = "cefPdfQuery";
     const std::string jsCancelFunction = "cefPdfCancel";
 }

--- a/src/Job/Job.cpp
+++ b/src/Job/Job.cpp
@@ -9,6 +9,7 @@ Job::Job() :
     m_pageOrientation(PageOrientation::PORTRAIT),
     m_pageMargin(),
     m_backgrounds(false),
+    m_remoteTriggerRegistered(false),
     m_status(Job::Status::PENDING),
     m_callback()
 {
@@ -34,6 +35,16 @@ void Job::SetPageMargin(const CefString& pageMargin)
 void Job::SetBackgrounds(bool flag)
 {
     m_backgrounds = flag;
+}
+
+bool Job::GetRemoteTriggerRegistered()
+{
+    return m_remoteTriggerRegistered;
+}
+
+void Job::SetRemoteTriggerRegistered(bool flag)
+{
+    m_remoteTriggerRegistered = flag;
 }
 
 CefPdfPrintSettings Job::GetCefPdfPrintSettings() const

--- a/src/Job/Job.h
+++ b/src/Job/Job.h
@@ -59,6 +59,10 @@ public:
 
     void SetBackgrounds(bool flag = true);
 
+    bool GetRemoteTriggerRegistered();
+
+    void SetRemoteTriggerRegistered(bool flag = true);
+
     // Get prepared PDF setting for CEF
     CefPdfPrintSettings GetCefPdfPrintSettings() const;
 
@@ -76,6 +80,7 @@ private:
     PageOrientation m_pageOrientation;
     PageMargin m_pageMargin;
     bool m_backgrounds;
+    bool m_remoteTriggerRegistered;
     Status m_status;
     Callback m_callback;
 

--- a/src/Job/Manager.cpp
+++ b/src/Job/Manager.cpp
@@ -77,6 +77,22 @@ void Manager::Process(CefRefPtr<CefBrowser> browser, int httpStatusCode)
     }
 }
 
+void Manager::RegisterRemoteTrigger(CefRefPtr<CefBrowser> browser)
+{
+    auto it = Find(browser);
+    if (it != m_jobs.end()) {
+        it->job->SetRemoteTriggerRegistered();
+    }
+}
+
+void Manager::AbortIfRemoteTriggerUnregistered(CefRefPtr<CefBrowser> browser)
+{
+    auto it = Find(browser);
+    if (it != m_jobs.end() && !it->job->GetRemoteTriggerRegistered()) {
+        Abort(browser, ERR_ABORTED);
+    }
+}
+
 void Manager::Finish(CefRefPtr<CefBrowser> browser, const CefString& path, bool ok)
 {
     auto it = Find(browser);

--- a/src/Job/Manager.h
+++ b/src/Job/Manager.h
@@ -30,6 +30,10 @@ public:
 
     void Abort(CefRefPtr<CefBrowser> browser, CefLoadHandler::ErrorCode errorCode);
 
+    void RegisterRemoteTrigger(CefRefPtr<CefBrowser> browser);
+
+    void AbortIfRemoteTriggerUnregistered(CefRefPtr<CefBrowser> browser);
+
     void StopAll();
 
 private:

--- a/src/RenderProcessHandler.cpp
+++ b/src/RenderProcessHandler.cpp
@@ -6,7 +6,6 @@ namespace cefpdf {
 RenderProcessHandler::RenderProcessHandler() {}
 
 // CefRenderProcessHandler methods:
-// -----------------------------------------------------------------------------
 void RenderProcessHandler::OnContextCreated(
     CefRefPtr<CefBrowser> browser,
     CefRefPtr<CefFrame> frame,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,6 +218,8 @@ int main(int argc, char* argv[])
     commandLine->InitFromArgv(argc, argv);
 #endif // OS_WIN
 
+    bool remoteTrigger = commandLine->HasSwitch("remote-trigger") && !commandLine->HasSwitch("server");
+
     if (commandLine->HasSwitch("help") || commandLine->HasSwitch("h")) {
         printHelp(getExecutableName(commandLine));
         return 0;
@@ -228,13 +230,11 @@ int main(int argc, char* argv[])
         return 0;
     }
 
-    bool javascript = commandLine->HasSwitch("javascript") || commandLine->HasSwitch("remote-trigger");
+    bool javascript = commandLine->HasSwitch("javascript") || remoteTrigger;
     app->Initialize(mainArgs);
     app->SetDisableJavaScript(!javascript);
 
-    if (commandLine->HasSwitch("remote-trigger")) {
-        app->SetRemoteTrigger();
-    }
+    app->SetRemoteTrigger(remoteTrigger);
 
     return commandLine->HasSwitch("server") ? runServer(app, commandLine) : runJob(app, commandLine);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@ void printHelp(std::string name)
     std::cout << "                   If omitted some default margin is applied." << std::endl;
     std::cout << "  --javascript     Enable JavaScript." << std::endl;
     std::cout << "  --backgrounds    Print with backgrounds. Default is without." << std::endl;
+    std::cout << "  --remote-trigger Defer printing until page evaluates window.cefpdf.trigger()" << std::endl;
     std::cout << std::endl;
     std::cout << "Server options:" << std::endl;
     std::cout << "  --server         Start HTTP server" << std::endl;
@@ -227,8 +228,13 @@ int main(int argc, char* argv[])
         return 0;
     }
 
+    bool javascript = commandLine->HasSwitch("javascript") || commandLine->HasSwitch("remote-trigger");
     app->Initialize(mainArgs);
-    app->SetDisableJavaScript(!commandLine->HasSwitch("javascript"));
+    app->SetDisableJavaScript(!javascript);
+
+    if (commandLine->HasSwitch("remote-trigger")) {
+        app->SetRemoteTrigger();
+    }
 
     return commandLine->HasSwitch("server") ? runServer(app, commandLine) : runJob(app, commandLine);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@ void printHelp(std::string name)
     std::cout << "  --javascript     Enable JavaScript." << std::endl;
     std::cout << "  --backgrounds    Print with backgrounds. Default is without." << std::endl;
     std::cout << "  --remote-trigger Defer printing until page evaluates window.cefpdf.trigger()" << std::endl;
+    std::cout << "                   Remote trigger is not available in HTTP server mode." << std::endl;
     std::cout << std::endl;
     std::cout << "Server options:" << std::endl;
     std::cout << "  --server         Start HTTP server" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,11 +43,11 @@ void printHelp(std::string name)
     std::cout << "                   If omitted some default margin is applied." << std::endl;
     std::cout << "  --javascript     Enable JavaScript." << std::endl;
     std::cout << "  --backgrounds    Print with backgrounds. Default is without." << std::endl;
-    std::cout << "  --remote-trigger Defer printing until page evaluates:";
-    std::cout << "                   window.cefPdfQuery({request: \"trigger\", onSuccess: function () {}, onFailure: function () {}});";
-    std::cout << "                   Will abort immediately if the page doesn't evaluate:";
-    std::cout << "                   window.cefPdfQuery({request: \"register\", onSuccess: function () {}, onFailure: function () {}});";
-    std::cout << "                   synchronously during load (e.g. in a script tag in the body).";
+    std::cout << "  --remote-trigger Defer printing until page evaluates:" << std::endl;
+    std::cout << "                   window.cefPdfQuery({request: \"trigger\", onSuccess: function () {}, onFailure: function () {}});" << std::endl;
+    std::cout << "                   Will abort immediately if the page doesn't evaluate:" << std::endl;
+    std::cout << "                   window.cefPdfQuery({request: \"register\", onSuccess: function () {}, onFailure: function () {}});" << std::endl;
+    std::cout << "                   synchronously during load (e.g. in a script tag in the body)." << std::endl;
     std::cout << std::endl;
     std::cout << "Server options:" << std::endl;
     std::cout << "  --server         Start HTTP server" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,8 +43,11 @@ void printHelp(std::string name)
     std::cout << "                   If omitted some default margin is applied." << std::endl;
     std::cout << "  --javascript     Enable JavaScript." << std::endl;
     std::cout << "  --backgrounds    Print with backgrounds. Default is without." << std::endl;
-    std::cout << "  --remote-trigger Defer printing until page evaluates window.cefpdf.trigger()" << std::endl;
-    std::cout << "                   Remote trigger is not available in HTTP server mode." << std::endl;
+    std::cout << "  --remote-trigger Defer printing until page evaluates:";
+    std::cout << "                   window.cefPdfQuery({request: \"trigger\", onSuccess: function () {}, onFailure: function () {}});";
+    std::cout << "                   Will abort immediately if the page doesn't evaluate:";
+    std::cout << "                   window.cefPdfQuery({request: \"register\", onSuccess: function () {}, onFailure: function () {}});";
+    std::cout << "                   synchronously during load (e.g. in a script tag in the body).";
     std::cout << std::endl;
     std::cout << "Server options:" << std::endl;
     std::cout << "  --server         Start HTTP server" << std::endl;


### PR DESCRIPTION
This aborts generations started with remote trigger enabled if the page doesn't evaluate

`window.cefPdfQuery({request: "register", onSuccess: function () {}, onFailure: function () {}});`

synchronously during load.

this can be achieved by adding the following script tag to the body.

```
<script>window.cefPdfQuery({request: "register", onSuccess: function () {}, onFailure: function () {}});</script>
```

Helper functions are also removed for now until they can be inserted into the window object deterministically before load start.

Will update the readme in a second.

Fixes #6 
Fixes #20 