### PR TITLE
Add 4 new command line options:

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -324,14 +324,12 @@ void Client::OnRenderProcessTerminated(
 
 void Client::SetViewWidth(int viewWidth)
 {
-   RenderHandler *renderHandler = (RenderHandler*)(m_renderHandler.get());
-   renderHandler->SetViewWidth(viewWidth);
+   m_renderHandler->SetViewWidth(viewWidth);
 }
 
 void Client::SetViewHeight(int viewHeight)
 {
-   RenderHandler *renderHandler = (RenderHandler*)(m_renderHandler.get());
-   renderHandler->SetViewHeight(viewHeight);
+   m_renderHandler->SetViewHeight(viewHeight);
 }
 
 } // namespace cefpdf

--- a/src/Client.h
+++ b/src/Client.h
@@ -85,6 +85,8 @@ public:
     void SetViewWidth(int viewWidth);
     void SetViewHeight(int viewHeight);
 
+    void Process(CefRefPtr<CefBrowser> browser);
+
     // CefApp methods:
     virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override;
     virtual void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) override;

--- a/src/Client.h
+++ b/src/Client.h
@@ -78,6 +78,13 @@ public:
         }
     }
 
+    void SetDelay(int delay) {
+        m_delay = delay;
+    }
+
+    void SetViewWidth(int viewWidth);
+    void SetViewHeight(int viewHeight);
+
     // CefApp methods:
     virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override;
     virtual void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) override;
@@ -151,6 +158,7 @@ private:
     bool m_contextInitialized;
     bool m_running;
     bool m_stopAfterLastJob;
+    int  m_delay;
 
     CefRefPtr<CefPrintHandler> m_printHandler;
     CefRefPtr<CefRenderHandler> m_renderHandler;

--- a/src/Client.h
+++ b/src/Client.h
@@ -2,6 +2,7 @@
 #define CLIENT_H_
 
 #include "Job/Manager.h"
+#include "RenderHandler.h"
 
 #include "include/cef_app.h"
 #include "include/cef_client.h"
@@ -163,7 +164,7 @@ private:
     int  m_delay;
 
     CefRefPtr<CefPrintHandler> m_printHandler;
-    CefRefPtr<CefRenderHandler> m_renderHandler;
+    CefRefPtr<RenderHandler> m_renderHandler;
     CefRefPtr<CefRenderProcessHandler> m_renderProcessHandler;
 
     // Include the default reference counting implementation.

--- a/src/Job/Job.cpp
+++ b/src/Job/Job.cpp
@@ -10,7 +10,8 @@ Job::Job() :
     m_pageMargin(),
     m_backgrounds(false),
     m_status(Job::Status::PENDING),
-    m_callback()
+    m_callback(),
+    m_scale(100)
 {
     SetPageSize(cefpdf::constants::pageSize);
     SetPageMargin("default");
@@ -36,10 +37,17 @@ void Job::SetBackgrounds(bool flag)
     m_backgrounds = flag;
 }
 
+void Job::SetScale(int scale)
+{
+    DLOG(INFO) << "Scale factor: " << m_scale;
+    m_scale = scale;
+}
+
 CefPdfPrintSettings Job::GetCefPdfPrintSettings() const
 {
     CefPdfPrintSettings pdfSettings;
 
+    pdfSettings.scale_factor = m_scale;
     pdfSettings.backgrounds_enabled = m_backgrounds;
     pdfSettings.landscape = (m_pageOrientation == PageOrientation::LANDSCAPE);
 

--- a/src/Job/Job.cpp
+++ b/src/Job/Job.cpp
@@ -39,7 +39,7 @@ void Job::SetBackgrounds(bool flag)
 
 void Job::SetScale(int scale)
 {
-    DLOG(INFO) << "Scale factor: " << m_scale;
+    DLOG(INFO) << "Scale factor: " << scale;
     m_scale = scale;
 }
 

--- a/src/Job/Job.h
+++ b/src/Job/Job.h
@@ -59,6 +59,8 @@ public:
 
     void SetBackgrounds(bool flag = true);
 
+    void SetScale(int scale);
+
     // Get prepared PDF setting for CEF
     CefPdfPrintSettings GetCefPdfPrintSettings() const;
 
@@ -78,6 +80,7 @@ private:
     bool m_backgrounds;
     Status m_status;
     Callback m_callback;
+    int m_scale;
 
     // Include the default reference counting implementation.
     IMPLEMENT_REFCOUNTING(Job)

--- a/src/RenderHandler.cpp
+++ b/src/RenderHandler.cpp
@@ -2,7 +2,23 @@
 
 namespace cefpdf {
 
-RenderHandler::RenderHandler() {}
+RenderHandler::RenderHandler() 
+{
+    m_viewWidth = 128;
+    m_viewHeight = 128;
+}
+
+void RenderHandler::SetViewWidth(int viewWidth)
+{
+    m_viewWidth = viewWidth;
+    DLOG(INFO) << "View width: " << m_viewWidth;
+}
+
+void RenderHandler::SetViewHeight(int viewHeight)
+{
+    m_viewHeight = viewHeight;
+    DLOG(INFO) << "View height: " << m_viewHeight;
+}
 
 // CefRenderHandler methods:
 // -------------------------------------------------------------------------
@@ -10,8 +26,8 @@ bool RenderHandler::GetViewRect(CefRefPtr<CefBrowser> browser, CefRect& rect)
 {
     rect.x = 0;
     rect.y = 0;
-    rect.width = 128;
-    rect.height = 128;
+    rect.width = m_viewWidth;
+    rect.height = m_viewHeight;
     return true;
 }
 

--- a/src/RenderHandler.h
+++ b/src/RenderHandler.h
@@ -11,6 +11,9 @@ class RenderHandler : public CefRenderHandler
 public:
     RenderHandler();
 
+    void SetViewWidth(int viewWidth);
+    void SetViewHeight(int viewHeight);
+
     // CefRenderHandler methods:
     virtual bool GetViewRect(CefRefPtr<CefBrowser> browser, CefRect& rect) override;
 
@@ -24,7 +27,10 @@ public:
 private:
     // Include the default reference counting implementation.
     IMPLEMENT_REFCOUNTING(RenderHandler)
-};
+
+    int m_viewWidth;
+    int m_viewHeight;
+   };
 
 } // namespace cefpdf
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,10 @@ void printHelp(std::string name)
     std::cout << "                   If omitted some default margin is applied." << std::endl;
     std::cout << "  --javascript     Enable JavaScript." << std::endl;
     std::cout << "  --backgrounds    Print with backgrounds. Default is without." << std::endl;
+    std::cout << "  --scale=<%>      Scale the output. Default is 100." << std::endl;
+    std::cout << "  --delay=<ms>     Wait after page load before creating PDF. Default is 0." << std::endl;
+    std::cout << "  --viewwidth=<px> Width of viewport. Default is 128." << std::endl;
+    std::cout << "  --viewheight=<px> Height of viewport. Default is 128." << std::endl;
     std::cout << std::endl;
     std::cout << "Server options:" << std::endl;
     std::cout << "  --server         Start HTTP server" << std::endl;
@@ -130,6 +134,22 @@ int runJob(CefRefPtr<cefpdf::Client> app, CefRefPtr<CefCommandLine> commandLine)
 
         if (commandLine->HasSwitch("backgrounds")) {
             job->SetBackgrounds();
+        }
+
+        if (commandLine->HasSwitch("scale")) {
+            job->SetScale(atoi(commandLine->GetSwitchValue("scale").ToString().c_str()));
+        }
+
+        if (commandLine->HasSwitch("delay")) {
+            app->SetDelay(atoi(commandLine->GetSwitchValue("delay").ToString().c_str()));
+        }
+
+        if (commandLine->HasSwitch("viewwidth")) {
+            app->SetViewWidth(atoi(commandLine->GetSwitchValue("viewwidth").ToString().c_str()));
+        }
+
+        if (commandLine->HasSwitch("viewheight")) {
+            app->SetViewHeight(atoi(commandLine->GetSwitchValue("viewheight").ToString().c_str()));
         }
 
     } catch (std::string error) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,29 +30,29 @@ void printHelp(std::string name)
     std::cout << "  cef-pdf [options] --url=<url>|--file=<path> [output]" << std::endl;
     std::cout << std::endl;
     std::cout << "Options:" << std::endl;
-    std::cout << "  --help -h        This help screen." << std::endl;
-    std::cout << "  --url=<url>      URL to load, may be http, file, data, anything supported by Chromium." << std::endl;
-    std::cout << "  --file=<path>    File path to load using file:// scheme. May be relative to current directory." << std::endl;
-    std::cout << "  --stdin          Read content from standard input until EOF (Unix: Ctrl+D, Windows: Ctrl+Z)." << std::endl;
-    std::cout << "  --size=<spec>    Size (format) of the paper: A3, B2.. or custom <width>x<height> in mm." << std::endl;
-    std::cout << "                   " << cefpdf::constants::pageSize << " is the default." << std::endl;
-    std::cout << "  --list-sizes     Show all defined page sizes." << std::endl;
-    std::cout << "  --landscape      Wheather to print with a landscape page orientation." << std::endl;
-    std::cout << "                   Default is portrait." << std::endl;
-    std::cout << "  --margin=<spec>  Paper margins in mm (much like CSS margin but without units)" << std::endl;
-    std::cout << "                   If omitted some default margin is applied." << std::endl;
-    std::cout << "  --javascript     Enable JavaScript." << std::endl;
-    std::cout << "  --backgrounds    Print with backgrounds. Default is without." << std::endl;
-    std::cout << "  --scale=<%>      Scale the output. Default is 100." << std::endl;
-    std::cout << "  --delay=<ms>     Wait after page load before creating PDF. Default is 0." << std::endl;
-    std::cout << "  --viewwidth=<px> Width of viewport. Default is 128." << std::endl;
+    std::cout << "  --help -h         This help screen." << std::endl;
+    std::cout << "  --url=<url>       URL to load, may be http, file, data, anything supported by Chromium." << std::endl;
+    std::cout << "  --file=<path>     File path to load using file:// scheme. May be relative to current directory." << std::endl;
+    std::cout << "  --stdin           Read content from standard input until EOF (Unix: Ctrl+D, Windows: Ctrl+Z)." << std::endl;
+    std::cout << "  --size=<spec>     Size (format) of the paper: A3, B2.. or custom <width>x<height> in mm." << std::endl;
+    std::cout << "                    " << cefpdf::constants::pageSize << " is the default." << std::endl;
+    std::cout << "  --list-sizes      Show all defined page sizes." << std::endl;
+    std::cout << "  --landscape       Wheather to print with a landscape page orientation." << std::endl;
+    std::cout << "                    Default is portrait." << std::endl;
+    std::cout << "  --margin=<spec>   Paper margins in mm (much like CSS margin but without units)" << std::endl;
+    std::cout << "                    If omitted some default margin is applied." << std::endl;
+    std::cout << "  --javascript      Enable JavaScript." << std::endl;
+    std::cout << "  --backgrounds     Print with backgrounds. Default is without." << std::endl;
+    std::cout << "  --scale=<%>       Scale the output. Default is 100." << std::endl;
+    std::cout << "  --delay=<ms>      Wait after page load before creating PDF. Default is 0." << std::endl;
+    std::cout << "  --viewwidth=<px>  Width of viewport. Default is 128." << std::endl;
     std::cout << "  --viewheight=<px> Height of viewport. Default is 128." << std::endl;
     std::cout << std::endl;
     std::cout << "Server options:" << std::endl;
-    std::cout << "  --server         Start HTTP server" << std::endl;
-    std::cout << "  --host=<host>    If starting server, specify ip address to bind to." << std::endl;
-    std::cout << "                   Default is " << cefpdf::constants::serverHost << std::endl;
-    std::cout << "  --port=<port>    Specify server port number. Default is " << cefpdf::constants::serverPort << std::endl;
+    std::cout << "  --server          Start HTTP server" << std::endl;
+    std::cout << "  --host=<host>     If starting server, specify ip address to bind to." << std::endl;
+    std::cout << "                    Default is " << cefpdf::constants::serverHost << std::endl;
+    std::cout << "  --port=<port>     Specify server port number. Default is " << cefpdf::constants::serverPort << std::endl;
     std::cout << std::endl;
     std::cout << "Output:" << std::endl;
     std::cout << "  PDF file name to create. Default is to write binary data to standard output." << std::endl;
@@ -137,19 +137,19 @@ int runJob(CefRefPtr<cefpdf::Client> app, CefRefPtr<CefCommandLine> commandLine)
         }
 
         if (commandLine->HasSwitch("scale")) {
-            job->SetScale(atoi(commandLine->GetSwitchValue("scale").ToString().c_str()));
+            job->SetScale(std::atoi(commandLine->GetSwitchValue("scale").ToString().c_str()));
         }
 
         if (commandLine->HasSwitch("delay")) {
-            app->SetDelay(atoi(commandLine->GetSwitchValue("delay").ToString().c_str()));
+            app->SetDelay(std::atoi(commandLine->GetSwitchValue("delay").ToString().c_str()));
         }
 
         if (commandLine->HasSwitch("viewwidth")) {
-            app->SetViewWidth(atoi(commandLine->GetSwitchValue("viewwidth").ToString().c_str()));
+            app->SetViewWidth(std::atoi(commandLine->GetSwitchValue("viewwidth").ToString().c_str()));
         }
 
         if (commandLine->HasSwitch("viewheight")) {
-            app->SetViewHeight(atoi(commandLine->GetSwitchValue("viewheight").ToString().c_str()));
+            app->SetViewHeight(std::atoi(commandLine->GetSwitchValue("viewheight").ToString().c_str()));
         }
 
     } catch (std::string error) {


### PR DESCRIPTION
-scale=<pct> to set pdfSettings.scale_factor
-delay=<ms> to delay after page load before rendering pdf (in my case allowed D3 charts to finish animating before creating the PDF)
-viewwidth=<px> to set viewport width (in my case setting the width to 1600 fixed a table that was trying to size to 100% and getting cut off at 128px wide, which is the default)
-viewheight=<px> added for parity, could be useful if element was specified as height=100%